### PR TITLE
・クエスト登録機能追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import pandas as pd
+from datetime import datetime, date, time
 
 # ページ設定
 st.set_page_config(page_title="チャジンジャー", page_icon=":guardsman:", layout="wide")
@@ -63,8 +64,136 @@ if 'quests' not in st.session_state:
 
 # ステータス一覧の初期化
 if 'statuses' not in st.session_state:
-    st.session_state.statuses = ["受注中", "進行中", "承認待ち", "完了"]
+    st.session_state.statuses = ["未受注", "進行中", "承認待ち", "完了"]
 
+# クエスト発行モーダルの状態管理
+if 'show_create_modal' not in st.session_state:
+    st.session_state.show_create_modal = False
+
+# 次のクエストIDを管理
+if 'next_quest_id' not in st.session_state:
+    st.session_state.next_quest_id = max([q['id'] for q in st.session_state.quests]) + 1
+# =============================================================================
+# クエスト発行ボタン（メイン画面に表示）
+# =============================================================================
+
+# ボタンレイアウト
+col1, col2, col3 = st.columns([1, 2, 1])
+with col2:
+    if st.button("クエスト発行する", key="create_quest_btn", type="primary", use_container_width=True):
+        st.session_state.show_create_modal = True
+
+# 区切り線
+st.markdown("---")
+# =============================================================================
+# クエスト発行ポップアップ（モーダル）
+# =============================================================================
+# ポップアップを表示する条件をチェック
+if st.session_state.show_create_modal:
+    
+    # タイトル表示
+    with st.container():
+        st.markdown("## 🎯 新規クエスト発行")
+        st.markdown("---")
+        
+        # フォーム入力エリア（2列レイアウト）
+        form_col1, form_col2 = st.columns([1, 1])
+        
+        # 左列：依頼側の情報
+        with form_col1:
+            st.markdown("#### 📝 クエスト情報")
+            quest_title = st.text_input(
+                "クエストタイトル", 
+                placeholder="例: お風呂の掃除をしてください", 
+                key="quest_title_input"
+            )
+            
+            quest_description = st.text_area(
+                "詳細説明", 
+                placeholder="例: お風呂の掃除をしてください。\nシャンプーが少なくなっているので詰め替えもよろしくね。", 
+                height=120, 
+                key="quest_desc_input"
+            )
+            
+            requester_name = st.text_input(
+                "依頼者", 
+                placeholder="例: お母さん", 
+                key="quest_requester_input"
+            )
+            
+            requester_email = st.text_input(
+                "メールアドレス", 
+                placeholder="example@email.com", 
+                key="quest_email_input"
+            )
+        
+        # 右列：期限・報酬情報
+        with form_col2:
+            st.markdown("#### ⏰ 期限・報酬")
+            quest_date = st.date_input(
+                "期限日", 
+                value=date.today(), 
+                key="quest_date_input"
+            )
+            
+            quest_time = st.time_input(
+                "期限時刻", 
+                value=time(19, 0), 
+                key="quest_time_input"
+            )
+            
+            quest_reward = st.text_input(
+                "報酬", 
+                placeholder="例: クリームパン 1個", 
+                key="quest_reward_input"
+            )
+        
+        # ボタン配置エリア
+        st.markdown("<br>", unsafe_allow_html=True)
+        
+        # ボタンを中央に配置
+        btn_col1, btn_col2= st.columns([1, 1])
+        
+        # クエスト依頼ボタン
+        with btn_col1:
+            if st.button("クエストを依頼する", key="submit_quest", type="primary", use_container_width=True):
+                # 入力値の検証
+                if quest_title and quest_description and requester_email and quest_reward:
+                    # 新しいクエストを作成
+                    new_quest = {
+                        "id": st.session_state.next_quest_id,
+                        "title": quest_title,
+                        "description": quest_description,
+                        "status": "未受注",  # 最初は「未受注」で登録します。
+                        "reward": quest_reward,  # 文字列として保存
+                        "deadline": f"{quest_date} {quest_time.strftime('%H:%M')}",
+                        "created_by": requester_name,  # 依頼者名を保存
+                        "email": requester_email       # メールアドレスを別項目で保存
+                    }
+                    
+                    # クエストリストに追加
+                    st.session_state.quests.append(new_quest)
+                    st.session_state.next_quest_id += 1
+                    
+                    # モーダルを閉じる
+                    st.session_state.show_create_modal = False
+                    
+                    # 成功メッセージを表示して画面をリロード
+                    st.success("✅ クエストが正常に発行されました！")
+                    st.rerun()
+                else:
+                    st.error("❌ すべての項目を入力してください")
+        
+        with btn_col2:
+            # キャンセルボタン
+            if st.button("❌ キャンセル", key="cancel_quest", use_container_width=True):
+                st.session_state.show_create_modal = False
+                st.rerun()
+        
+        st.markdown("---")
+    
+    # モーダルが表示されている時は、下のコンテンツの表示を抑制
+    st.stop()
 # =============================================================================
 # メインコンテンツ：カンバンボード表示
 # =============================================================================
@@ -83,11 +212,14 @@ for i, status in enumerate(st.session_state.statuses):
 
         # 各クエストをカード形式で表示
         for quest in quests:
+            # 報酬の表示形式を調整（数値の場合はポイント、文字列の場合はそのまま表示）
+            reward_display = f"{quest['reward']}ポイント" if isinstance(quest['reward'], int) else quest['reward']
+            
             # HTMLカード + JavaScriptクリック処理
             st.markdown(f'''
             <div class="card" onclick="document.getElementById('btn_{quest["id"]}').click()">
                 <h4>{quest["title"]}</h4>
-                <p>報酬: {quest["reward"]}ポイント</p>
+                <p>報酬: {reward_display}</p>
             </div>
             ''', unsafe_allow_html=True)
             
@@ -105,12 +237,15 @@ if 'selected_quest' in st.session_state:
     selected = next((q for q in st.session_state.quests if q['id'] == st.session_state.selected_quest), None)
     
     if selected:
+        # 報酬の表示形式を調整
+        reward_display = f"{selected['reward']}ポイント" if isinstance(selected['reward'], int) else selected['reward']
+        
         # モーダル風の詳細表示（固定位置）
         st.markdown(f"""
         <div style="position: fixed; top: 20%; left: 30%; width: 40%; background-color: white; border: 2px solid #000; border-radius: 10px; padding: 20px; z-index: 1000;">
             <h3>{selected['title']}</h3>
             <p><strong>説明:</strong> {selected['description']}</p>
-            <p><strong>報酬:</strong> {selected['reward']}ポイント</p>
+            <p><strong>報酬:</strong> {reward_display}</p>
             <p><strong>期限:</strong> {selected['deadline']}</p>
             <p><strong>作成者:</strong> {selected['created_by']}</p>
         </div>


### PR DESCRIPTION
・看板ボードの報酬箇所を数ではなく、テキスト記入で自由入力できるようステータス変更
・ステータス一覧初期化箇所：「ダミーデータにあわせ、未受注、進行中、承認待ち、完了」の４ステータスへ変更